### PR TITLE
사파리 브라우저에서 UI 깨짐 문제 해결

### DIFF
--- a/client/src/components/organisms/MainLink.tsx
+++ b/client/src/components/organisms/MainLink.tsx
@@ -25,7 +25,7 @@ const MainLink: React.FC<MainLinkProps> = ({ buttonText, src, nav }) => {
           height: '100%',
         }}
       >
-        <StyledImg src={src} />
+        <StyledImgMd src={src} />
         <Button variant='outlined' sx={{ borderRadius: '20px' }}>
           {buttonText}
         </Button>
@@ -40,10 +40,10 @@ const MainLink: React.FC<MainLinkProps> = ({ buttonText, src, nav }) => {
           },
 
           width: '100%',
-          height: 'calc(100% / 2)',
+          height: 'calc(100% / 1.5)',
         }}
       >
-        <StyledImg src={src} />
+        <StyledImgSm src={src} width='20%' />
 
         <Button variant='outlined' sx={{ borderRadius: '20px', fontSize: '10px' }}>
           {buttonText}
@@ -61,7 +61,7 @@ const MainLink: React.FC<MainLinkProps> = ({ buttonText, src, nav }) => {
           height: 'calc(100% / 3)',
         }}
       >
-        <StyledImg2 src={src} />
+        <StyledImgXs src={src} />
 
         <Button variant='outlined' sx={{ borderRadius: '20px', fontSize: '8px' }}>
           {buttonText}
@@ -71,11 +71,15 @@ const MainLink: React.FC<MainLinkProps> = ({ buttonText, src, nav }) => {
   );
 };
 
-const StyledImg = styled.img`
+const StyledImgMd = styled.img`
   width: 35%;
   margin: 30px;
 `;
-const StyledImg2 = styled.img`
+const StyledImgSm = styled.img`
+  width: 35%;
+  margin: 20px;
+`;
+const StyledImgXs = styled.img`
   height: 30%;
   margin: 15px;
 `;

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -3,16 +3,18 @@ import MainLink from '~/components/organisms/MainLink';
 import notice from '../../public/img/noticeIcon.svg';
 import community from '../../public/img/communityIcon.svg';
 import complaint from '../../public/img/complaintIcon.svg';
-import { ReactComponent as MainImage } from '../../public/img/homeMain.svg';
 import { Box, Typography } from '@mui/material';
 
 //이미지와 텍스트를 감싸고 있는 요소
 const StyledContainer = styled.div`
   position: relative;
+  height: 80%;
 `;
 // 텍스트를 감싸고 있는 요소
 const StyledContainerText = styled.div`
   text-align: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
   justify-contents: center;
   width: 100%;
@@ -26,59 +28,94 @@ const StyledContainerText = styled.div`
 
 const StyledContainerBtn = styled.div`
   width: 52%;
-  height:70%;
+  height: 70%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
-  justify-content: 'space-between',
+  -webkit-box-pack: 'space-between';
+  -ms-flex-pack: 'space-between';
+  justify-content: 'space-between';
   color: black;
-  margin:5% 0 0 0;
+  margin: 5% 0 0 0;
   position: absolute;
   font-family: BlinkMacSystemFont;
   top: 50%;
   left: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
 `;
 const StyledContainerBtn2 = styled.div`
   width: 80%;
-  height:90%;
+  height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
-  justify-items:center;
- 
-  justify-content: 'space-between',
+  justify-items: center;
+
+  -webkit-box-pack: 'space-between';
+
+  -ms-flex-pack: 'space-between';
+
+  justify-content: 'space-between';
   color: black;
-  margin:5% 0 0 0;
+  margin: 5% 0 0 0;
   position: absolute;
   font-family: BlinkMacSystemFont;
   top: 50%;
   left: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
 `;
 const StyledContainerBtn3 = styled.div`
   width: 90%;
-  height:90%;
+  height: 90%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
-  justify-items:center;
-  flex-direction:column;
-  justify-content: 'space-between',
+  justify-items: center;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: 'space-between';
+  -ms-flex-pack: 'space-between';
+  justify-content: 'space-between';
   color: black;
-  margin:5% 0 0 0;
+  margin: 5% 0 0 0;
   position: absolute;
   font-family: BlinkMacSystemFont;
   top: 55%;
   left: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
+`;
+
+const StyledImage = styled.img`
+  width: 100%;
+  height: 100%;
 `;
 
 const HomePage = () => {
   return (
     <StyledHome>
       <StyledContainer>
-        <MainImage width='100%' />
+        <StyledImage src='../../public/img/homeMain.svg' />
+
         <StyledContainerText>
           <Typography
-            sx={{ display: { xs: 'none', md: 'block' }, fontSize: '35px', fontWeight: 700 }}
+            sx={{ display: { xs: 'none', md: 'block' }, fontSize: '30px', fontWeight: 700 }}
           >
             작은 관심으로 따뜻한 이웃 사이를 만드는 서비스, 오늘도 이웃사이 하세요
           </Typography>
@@ -88,7 +125,7 @@ const HomePage = () => {
             sx={{
               display: { xs: 'block', sm: 'none', md: 'none' },
               margin: '2px',
-              fontSize: '18px',
+              fontSize: '14px',
               fontFamily: 'monospace',
               fontWeight: 600,
             }}
@@ -100,7 +137,7 @@ const HomePage = () => {
             noWrap
             sx={{
               display: { xs: 'block', sm: 'none', md: 'none' },
-              fontSize: '18px',
+              fontSize: '16px',
               fontFamily: 'monospace',
 
               fontWeight: 600,
@@ -179,9 +216,16 @@ const linkData = [
 ];
 
 const StyledHome = styled('div')`
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content: center;
+  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   height: calc(100vh - 70px);
 `;


### PR DESCRIPTION
기존 UI의 경우 chrome 및 파이어폭스에서는 정상작동했지만, safari에서는 깨지는 문제가 발생하였습니다.
이를 해결하기 위해 webkit 키워드를 추가하였고, height도 추가하여 문제를 해결하였습니다. 
키워드 추가는 https://autoprefixer.github.io/ 를 통해 아주 쉽게 적용했습니다!!
(그런데 아마 본질적으로 깨졌던 이유는.. height를 적용해주지 않아 생긴 문제였던 것 같습니다 ㅠㅠ)

크롬
<img width="1552" alt="Screen Shot 2022-10-20 at 10 59 24 AM" src="https://user-images.githubusercontent.com/62577565/196866828-4c5a1988-9a51-47b7-8918-e094b27c6798.png">

파이어폭스
<img width="1552" alt="Screen Shot 2022-10-20 at 10 59 12 AM" src="https://user-images.githubusercontent.com/62577565/196867213-a4e96ddb-b6ad-4f9d-b87b-b6ed963f4505.png">

사파리(문제의.. 그 브라우저..^^)
<img width="1254" alt="Screen Shot 2022-10-20 at 10 59 43 AM" src="https://user-images.githubusercontent.com/62577565/196865291-c12ce965-059f-43a8-ace9-b12748d041a9.png">


--------------- 수정 후 -----------------

<img width="1552" alt="Screen Shot 2022-10-20 at 2 57 01 PM" src="https://user-images.githubusercontent.com/62577565/196867672-f965d042-89ea-4fa9-bf13-b3a0e5d0f296.png">


사파리 개발자 모드에서 확인한 결과 다음과 같이 다른 기종에서도 문제없이 올바르게 적용됩니다 :)

<img width="847" alt="Screen Shot 2022-10-20 at 2 36 44 PM" src="https://user-images.githubusercontent.com/62577565/196865261-52af5a24-24f2-4ad1-9572-95b198971845.png">
<img width="847" alt="Screen Shot 2022-10-20 at 2 36 30 PM" src="https://user-images.githubusercontent.com/62577565/196865275-901ae406-6470-4f07-855e-42ad0f0921ab.png">
<img width="847" alt="Screen Shot 2022-10-20 at 2 36 27 PM" src="https://user-images.githubusercontent.com/62577565/196865286-69b4664b-9150-40b2-b837-ec6e95384568.png">

... 혹 문제가 생기면 다시 수정하겠습니다 ..^^

